### PR TITLE
[FIX] Store the supplier price on a supplierinfo linked to the partner of the actual purchase order. Prices linked to the invoicing partner are ignored in further purchases of the same product

### DIFF
--- a/product_supplier_price_from_invoice/i18n/nl.po
+++ b/product_supplier_price_from_invoice/i18n/nl.po
@@ -1,13 +1,13 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-#	* product_price_update_from_invoice
+#	* product_supplier_price_from_invoice
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-30 14:33+0000\n"
-"PO-Revision-Date: 2014-10-30 14:33+0000\n"
+"POT-Creation-Date: 2014-11-21 11:53+0000\n"
+"PO-Revision-Date: 2014-11-21 11:53+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,91 +15,111 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: product_price_update_from_invoice
+#. module: product_supplier_price_from_invoice
+#: view:account.invoice.updateprice:0
+msgid "Cancel"
+msgstr "Annuleer"
+
+#. module: product_supplier_price_from_invoice
+#: code:_description:0
+#: model:ir.model,name:product_supplier_price_from_invoice.model_account_invoice
+#, python-format
+msgid "Invoice"
+msgstr "Factuur"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice.line,invoice_price:0
+msgid "Invoice price"
+msgstr "Prijs op factuur"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice.line,new_price:0
+msgid "New price"
+msgstr "Nieuwe prijs"
+
+#. module: product_supplier_price_from_invoice
+#: help:account.invoice.updateprice.line,new_price:0
+msgid "New price you will want to set in the product"
+msgstr "Nieuwe prijs voor dit product voor deze leverancier"
+
+#. module: product_supplier_price_from_invoice
+#: view:account.invoice.updateprice:0
+msgid "Please register the current supplier price per single unit. If the price is already correctly registered, you can leave the New price field empty. The price on the current invoice will be updated as well. Current prices are excluding discounts."
+msgstr "Leg hier de huidige leveranciersprijzen per stuk vast. Als de weergegeven prijs al correct is, dan kan het veld voor de nieuwe prijs leeg worden gelaten. De prijs op de huidige factuur zal ook worden geupdate. Alle prijzen zijn zonder eventuele korting."
+
+#. module: product_supplier_price_from_invoice
+#: help:account.invoice.updateprice.line,supplier_price:0
+msgid "Price already saved in your product"
+msgstr "Huidige leveranciersprijs in de productinstellingen"
+
+#. module: product_supplier_price_from_invoice
+#: view:account.invoice.updateprice:0
+msgid "Price update for "
+msgstr "Prijzen bijwerken voor "
+
+#. module: product_supplier_price_from_invoice
+#: help:account.invoice.updateprice.line,invoice_price:0
+msgid "Price you have just received in the invoice"
+msgstr "Prijs op deze factuur"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice.line,product_id:0
+msgid "Product name"
+msgstr "Product"
+
+#. module: product_supplier_price_from_invoice
 #: view:account.invoice.updateprice:0
 msgid "Save"
 msgstr "Opslaan"
 
-#. module: product_price_update_from_invoice
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice,partner_id:0
+msgid "Supplier"
+msgstr "Supplier"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice,supplier_name:0
+msgid "Supplier name"
+msgstr "Leverancier"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice.line,supplier_price:0
+msgid "Supplier price "
+msgstr "Leveranciersprijs"
+
+#. module: product_supplier_price_from_invoice
+#: field:account.invoice.updateprice,account_invoice_id:0
+msgid "The invoice this object has been generated from"
+msgstr "The invoice this object has been generated from"
+
+#. module: product_supplier_price_from_invoice
 #: view:account.invoice:0
 #: view:account.invoice.updateprice:0
 msgid "Update Prices"
 msgstr "Leveranciersprijzen bijwerken"
 
-#. module: product_price_update_from_invoice
-#: model:ir.model,name:account_invoice_updateprice.model_account_invoice
-msgid "Invoice"
-msgstr "Factuur"
+#. module: product_supplier_price_from_invoice
+#: code:_description:0
+#: model:ir.model,name:product_supplier_price_from_invoice.model_account_invoice_updateprice
+#, python-format
+msgid "Update Prices on this invoice"
+msgstr "Prijzen op deze factuur bijwerken"
 
-#. module: product_price_update_from_invoice
-#: model:ir.model,name:account_invoice_updateprice.model_account_invoice_updateprice_line
-msgid "update price lines"
-msgstr "Prijzen bijwerken - regel"
+#. module: product_supplier_price_from_invoice
+#: view:account.invoice.updateprice:0
+msgid "or"
+msgstr "of"
 
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice,account_invoice_id:0
+#. module: product_supplier_price_from_invoice
 #: field:account.invoice.updateprice,update_price_line_ids:0
 #: field:account.invoice.updateprice.line,updateprice_id:0
 msgid "unknown"
 msgstr "onbekend"
 
-#. module: product_price_update_from_invoice
-#: help:account.invoice.updateprice.line,new_price:0
-msgid "New price you will want to set in the product"
-msgstr "Nieuwe prijs voor dit product voor deze leverancier"
-
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice.line,supplier_price:0
-msgid "Supplier price "
-msgstr "Leveranciersprijs"
-
-#. module: product_price_update_from_invoice
-#: help:account.invoice.updateprice.line,invoice_price:0
-msgid "Price you have just received in the invoice"
-msgstr "Prijs op deze factuur"
-
-#. module: product_price_update_from_invoice
-#: model:ir.model,name:account_invoice_updateprice.model_account_invoice_updateprice
-msgid "Update Prices on this invoice"
-msgstr "Productprijzen op factuur bijwerken"
-
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice.line,new_price:0
-msgid "Price to set"
-msgstr "Werkelijke prijs"
-
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice.line,invoice_price:0
-msgid "Invoice price"
-msgstr "Prijs op factuur"
-
-#. module: product_price_update_from_invoice
-#: view:account.invoice.updateprice:0
-msgid "Cancel"
-msgstr "Annuleer"
-
-#. module: product_price_update_from_invoice
-#: help:account.invoice.updateprice.line,supplier_price:0
-msgid "Price already saved in your product"
-msgstr "Huidige leveranciersprijs in de productinstellingen"
-
-#. module: product_price_update_from_invoice
-#: view:account.invoice.updateprice:0
-msgid "price update - current prices are excluding discount."
-msgstr "prijzen bijwerken - alle prijzen in dit scherm zijn zonder korting"
-
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice,supplier_name:0
-msgid "Supplier name"
-msgstr "Leverancier"
-
-#. module: product_price_update_from_invoice
-#: view:account.invoice.updateprice:0
-msgid "or"
-msgstr "of"
-
-#. module: product_price_update_from_invoice
-#: field:account.invoice.updateprice.line,product_id:0
-msgid "Product name"
-msgstr "Product"
+#. module: product_supplier_price_from_invoice
+#: code:_description:0
+#: model:ir.model,name:product_supplier_price_from_invoice.model_account_invoice_updateprice_line
+#, python-format
+msgid "update price lines"
+msgstr "update price lines"
 

--- a/product_supplier_price_from_invoice/model/account_invoice_updateprice.py
+++ b/product_supplier_price_from_invoice/model/account_invoice_updateprice.py
@@ -110,6 +110,8 @@ class UpdatePrice(orm.TransientModel):
         partner. Supplier pricelists don't generalize within the same
         partner, but are only retrieved by contact. As a workaround, take
         the partner from the related purchase if any as a best guess.
+        If no purchase order can be found, pick the commercial partner
+        over an invoice partner.
         """
         purchase_obj = self.pool['purchase.order']
         res = {}
@@ -123,7 +125,10 @@ class UpdatePrice(orm.TransientModel):
                 res[wiz.id] = purchase.partner_id.id
                 print purchase.partner_id.name
             else:
-                res[wiz.id] = wiz.account_invoice_id.partner_id.id
+                partner = wiz.account_invoice_id.partner_id
+                if partner.type == 'invoice':
+                    partner = partner.commercial_partner_id
+                res[wiz.id] = partner.id
         return res
 
     _columns = {

--- a/product_supplier_price_from_invoice/view/account_invoice_updateprice.xml
+++ b/product_supplier_price_from_invoice/view/account_invoice_updateprice.xml
@@ -27,11 +27,7 @@
                                <field name="supplier_name"/>
                             </h3>
                             </group>
-                            <p colspan="2">Please register the current supplier price
-                            per single unit. If the price is already correctly registered,
-                            you can leave the <i>New price</i> field empty. The price on
-                            the current invoice will be updated as well.
-                            <i>Current prices are excluding discounts.</i></p>
+                            <p colspan="2">Please register the current supplier price per single unit. If the price is already correctly registered, you can leave the New price field empty. The price on the current invoice will be updated as well. Current prices are excluding discounts.</p>
                         </group>
                         <field name="update_price_line_ids" widget="one2many" >
                             <tree editable="bottom" create="false" delete="false">


### PR DESCRIPTION
[UPD] Translations. Inline style tags break the translation mechanism
